### PR TITLE
Change 'work' desktop shortcut to 'place'. Rename file and change key…

### DIFF
--- a/cookbooks/station/files/usr/share/applications/station/place.desktop
+++ b/cookbooks/station/files/usr/share/applications/station/place.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
-Name=Position Work Windows
+Name=Place Core Set of Windows
 Comment=Use the command line [maxdesktop]
-Keywords=shell;prompt;command;commandline;work
+Keywords=shell;prompt;command;commandline;place
 TryExec=gnome-terminal
 Exec=/usr/local/bin/position
 Icon=utilities-terminal


### PR DESCRIPTION
…word so Gnome can launch as 'place'