### PR TITLE
Mbs enable fedora 41

### DIFF
--- a/cookbooks/station/attributes/default.rb
+++ b/cookbooks/station/attributes/default.rb
@@ -407,6 +407,7 @@ node.default['station']['docker-engine'] = {
     'docker-ce',
     'docker-ce-cli',
     'containerd.io',
+    'docker-buildx-plugin',
     'docker-compose-plugin'
   ]
 }
@@ -2089,7 +2090,6 @@ case plat_vers
           'atari++': 'Unix based emulator of the Atari eight bit computers (fedora)',
           'atop': 'Better version of top',
           'autodownloader': 'GUI-tool to automate the download of certain files (updates)',
-          'apostrophe': 'Apostophe markdown editor with ascii text and WYSIWYG display',
           'bat': 'bat is an enhanced cat',
           'binutils': 'for VirtualBox-6.1 kernel modules',
           'bpytop': 'An enhanced top command, very modern.',
@@ -2262,8 +2262,6 @@ case plat_vers
           'thunar': 'Tree based file manager',
           'thunderbird': 'Mozilla Thunderbird mail/newsgroup client (updates)',
           'tigervnc-server': 'A TigerVNC server (updates)',
-          'ufraw-common': 'Common files needed by UFRaw (fedora)',
-          'ufraw-gimp': 'GIMP plugin to retrieve raw image data from digital cameras (fedora)',
           'unetbootin': 'Create bootable Live USB drives for a variety of Linux distributions (fedora)',
           'unrar': 'Utility for extracting, testing and viewing RAR archives (rpmfusion-nonfree-updates)',
           'usbview': 'USB topology and device viewer (fedora)',
@@ -2285,7 +2283,6 @@ case plat_vers
           'wodim': 'A command line CD/DVD recording program (fedora)',
           'xdpyinfo': 'X Display Utilities',
           'xrandr': 'X display utility',
-          'xsane-gimp': 'Scanner frontend for GIMP',
           'xsane': 'Scanner utility',
           'xwininfo': 'Xwindows window information utility'
         }

--- a/cookbooks/station/attributes/default.rb
+++ b/cookbooks/station/attributes/default.rb
@@ -2284,6 +2284,7 @@ case plat_vers
           'xdpyinfo': 'X Display Utilities',
           'xrandr': 'X display utility',
           'xsane': 'Scanner utility',
+          'xsane-gimp': 'xsane to Gimp integration',
           'xwininfo': 'Xwindows window information utility'
         }
 

--- a/cookbooks/station/recipes/docker_desktop.rb
+++ b/cookbooks/station/recipes/docker_desktop.rb
@@ -17,7 +17,7 @@ package node['station']['docker-desktop']['remove_conflict_packages'] do
 end
 
 execute 'dnf-new-repo' do
-    command 'dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo'
+    command 'dnf-3 config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo'
 
   not_if { ::File.exist?('/etc/yum.repos.d/docker-ce.repo') }
 end


### PR DESCRIPTION
    Enable Fedora 41: Add back xsane-gimp package

    Enable Fedora 41: Fix Docker
    
    Modify call to 'dnf' with call to 'dnf-3' to add docker repo.
    
    New 'dnf5' in Fedora 41 uses a different syntax

    Enable Fedora 41: Attributes changes
    
    * Add 'docker-buildx-plugin' rpm per Docker install instructions
    
    * Remove 'apostrophe' markdown reader as not found in repos
    
    * Remove 'ufraw-common' and 'ufraw-gimp' as not found in repos
    
    * Remove 'xsane-gimp' per initial errors